### PR TITLE
Document `stats.score` and `stats.downloads.pastWeek` in PackMetaData

### DIFF
--- a/docs/api/generated/data-types.inc
+++ b/docs/api/generated/data-types.inc
@@ -62,9 +62,11 @@
   stats: {
     updated: number?
     added: number
+    score: number // Used to calculate which pack is trending
     downloads: {
       total: number
       today: number
+      pastWeek: number
     }
   }
   owner: string


### PR DESCRIPTION
Closes #12

I am unsure of whether using comments is allowed in the type schema (it does compile and work, but haven't seen it being used in the docs as of now). **If not, it can be removed.**