### PR TITLE
Fix more file paths in `data-pack-menu.md`

### DIFF
--- a/docs/conventions/data-pack-menu.md
+++ b/docs/conventions/data-pack-menu.md
@@ -107,7 +107,7 @@ Dialogs can also specify exit actions that occur when using {kbd}`ESC` or clicki
 
 ::::{tab-item} Pause Screen Tag
 
-`data/minecraft/tags/dialogs/pause_screen_additions.json`
+`data/minecraft/tags/dialog/pause_screen_additions.json`
 ```json
 {
   "values": [
@@ -123,7 +123,7 @@ Dialogs can also specify exit actions that occur when using {kbd}`ESC` or clicki
 
 ::::{tab-item} Data Packs Tag
 
-`data/smithed/tags/dialogs/data_packs.json`
+`data/smithed/tags/dialog/data_packs.json`
 ```json
 {
   "values": [


### PR DESCRIPTION
https://github.com/Smithed-MC/Docs/commit/39de515171aaddb3dabdf13a79ac8878493ddd69 didn't completely fix every file path; this PR fixes the remaining issue of incorrectly pluralizing "dialog" in a few file paths.